### PR TITLE
Update SnapKit dependency

### DIFF
--- a/Mandoline.podspec
+++ b/Mandoline.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = {
     'Mandoline' => ['Mandoline/Assets/**/*']
   }
-  s.dependency 'SnapKit', '~> 4.0.0'
+  s.dependency 'SnapKit', '~> 4.2.0'
 end


### PR DESCRIPTION
The 4.0 SnapKit dependency no longer compiles with the latest version of Swift, updating the dependency to 4.2 fixes this.